### PR TITLE
Avoid non-deterministic behavior when animation channels are -1.

### DIFF
--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -170,6 +170,9 @@ ModelData* Raw2Gltf(
 
       for (size_t channelIx = 0; channelIx < animation.channels.size(); channelIx++) {
         const RawChannel& channel = animation.channels[channelIx];
+        if (channel.nodeIndex < 0) {
+          continue;
+        }
         const RawNode& node = raw.GetNode(channel.nodeIndex);
 
         if (verboseOutput) {


### PR DESCRIPTION
Co-Authored-By: DmLvkvch <31544742+DmLvkvch@users.noreply.github.com>