### PR TITLE
CI: Streamline names and contents of releases and artifacts

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: "Build FBX2GLTF"
+name: "Build FBX2glTF"
 on:
   pull_request:
     branches:
@@ -14,11 +14,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-win-10:
+  build-windows:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install conan
         run: |
@@ -82,11 +82,14 @@ jobs:
           ./build/Release/FBX2glTF.exe --help
         shell: bash
 
-      - name: Copy licenses
+      - name: Prepare artifacts
         run: |
-          mkdir -p result
-          cp sdk/Windows/2020.2/License.rtf thirdparty-license.rtf
-          cp build/Release/FBX2glTF.exe FBX2glTF.exe
+          export TARGET=FBX2glTF-windows-x86_64
+          mkdir $TARGET
+          cp sdk/Windows/2020.2/License.rtf $TARGET/FBX-SDK-License.rtf
+          cp LICENSE $TARGET/FBX2glTF-License.txt
+          cp build/Release/FBX2glTF.exe $TARGET/FBX2glTF-windows-x86_64.exe
+          7z a -r $TARGET.zip $TARGET
         shell: bash
 
       - name: Release
@@ -94,33 +97,22 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
-            thirdparty-license.rtf
-            LICENSE
-            FBX2glTF.exe
+            FBX2glTF-windows-x86_64.zip
+            FBX2glTF-windows-x86_64/FBX2glTF-License.txt
+            FBX2glTF-windows-x86_64/FBX-SDK-License.rtf
 
-      - name: FBX2glTF.exe
+      - name: FBX2glTF-windows-x86_64
         uses: actions/upload-artifact@v3
         with:
-          name: FBX2glTF.exe
-          path: FBX2glTF.exe
+          name: FBX2glTF-windows-x86_64
+          path: FBX2glTF-windows-x86_64/*
 
-      - name: thirdparty-license.rtf
-        uses: actions/upload-artifact@v3
-        with:
-          name: thirdparty-license.rtf
-          path: thirdparty-license.rtf
 
-      - name: Archive results
-        uses: actions/upload-artifact@v3
-        with:
-          name: LICENSE
-          path: LICENSE
-
-  build-ubuntu:
+  build-linux:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Install conan
         run: |
@@ -184,48 +176,39 @@ jobs:
           ./build/FBX2glTF --help
         shell: bash
 
-      - name: Copy licenses
+      - name: Prepare artifacts
         run: |
-          mkdir -p result
-          cp sdk/Linux/2020.2/License.txt thirdparty-license.txt
-          cp build/FBX2glTF FBX2glTF
+          export TARGET=FBX2glTF-linux-x86_64
+          mkdir $TARGET
+          cp sdk/Linux/2020.2/License.txt $TARGET/FBX-SDK-License.txt
+          cp LICENSE $TARGET/FBX2glTF-License.txt
+          cp build/FBX2glTF $TARGET/FBX2glTF-linux-x86_64
+          7z a -r $TARGET.zip $TARGET
         shell: bash
 
       - name: Release
-        if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            thirdparty-license.txt
-            LICENSE
-            FBX2glTF
+          files: FBX2glTF-linux-x86_64.zip
 
-      - name: Archive results
+      - name: FBX2glTF-linux-x86_64
         uses: actions/upload-artifact@v3
         with:
-          name: FBX2glTF
-          path: FBX2glTF
+          name: FBX2glTF-linux-x86_64
+          path: FBX2glTF-linux-x86_64/*
 
-      - name: thirdparty-license.txt
-        uses: actions/upload-artifact@v3
-        with:
-          name: thirdparty-license.txt
-          path: thirdparty-license.txt
 
-      - name: LICENSE
-        uses: actions/upload-artifact@v3
-        with:
-          name: LICENSE
-          path: LICENSE
-
-  build-macos-x86_64:
+  build-macos:
     runs-on: macos-11
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Update python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3'
 
       - name: Install conan
         run: |
@@ -294,36 +277,24 @@ jobs:
           codesign -s - --options=runtime build/FBX2glTF
         shell: bash
 
-      - name: Copy licenses
+      - name: Prepare artifacts
         run: |
-          mkdir -p result
-          cp sdk/Darwin/2020.2/License.rtf thirdparty-license.rtf
-          cp build/FBX2glTF FBX2glTF-macos-x86_64
+          export TARGET=FBX2glTF-macos-x86_64
+          mkdir $TARGET
+          cp sdk/Darwin/2020.2/License.rtf $TARGET/FBX-SDK-License.rtf
+          cp LICENSE $TARGET/FBX2glTF-License.txt
+          cp build/FBX2glTF $TARGET/FBX2glTF-macos-x86_64
+          7z a -r $TARGET.zip $TARGET
         shell: bash
 
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')
         with:
-          files: |
-            thirdparty-license.rtf
-            LICENSE
-            FBX2glTF-macos-x86_64
+          files: FBX2glTF-macos-x86_64.zip
 
       - name: FBX2glTF-macos-x86_64
         uses: actions/upload-artifact@v3
         with:
-          name: macos-packages
-          path: FBX2glTF-macos-x86_64
-
-      - name: thirdparty-license.rtf
-        uses: actions/upload-artifact@v3
-        with:
-          name: thirdparty-license.rtf
-          path: thirdparty-license.rtf
-
-      - name: LICENSE
-        uses: actions/upload-artifact@v3
-        with:
-          name: LICENSE
-          path: LICENSE
+          name: FBX2glTF-macos-x86_64
+          path: FBX2glTF-macos-x86_64/*

--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@ BSD License
 
 For FBX2glTF software
 
-Copyright (c) 2020-2021 V-Sekai Contributors (see credits in README.md)
+Copyright (c) 2020-2022 V-Sekai contributors.
 Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification,

--- a/README.md
+++ b/README.md
@@ -1,21 +1,38 @@
-# FBX2GLTF
+# FBX2glTF
 
-A command-line tool for the conversion of 3D model assets on the FBX file format to the glTF file format. 
+A command-line tool for the conversion of 3D model assets on the FBX file format
+to the glTF file format.
 
 Change skinning-weights to 4 if your engine does not support that feature.
 
 Change the default import of the engine to be different from 30 fps if needed.
 
+## License
+
+The FBX2glTF command line tool is distributed under the 3-clause BSD license.
+
+Precompiled binaries include **proprietary code** from the Autodesk FBX SDK 2020,
+which is distributed under the
+[Autodesk LICENSE AND SERVICES AGREEMENT](https://github.com/godotengine/FBX2glTF/releases/latest/download/FBX-SDK-License.rtf).
+
+**By downloading and using this tool, you agree to the terms of that Autodesk
+proprietary license.**
+
 ## Platform binaries
 
-`FBX2glTF` is for Linux and built on Ubuntu 20.04.
+Check the [latest release](https://github.com/godotengine/FBX2glTF/releases/latest/)
+for the last precompiled binaries for Linux, macOS, and Windows.
 
-`FBX2glTF-macos-x86_64` is for macos.
+- Linux x86_64: [`FBX2glTF-linux-x86_64.zip`](https://github.com/godotengine/FBX2glTF/releases/latest/download/FBX2glTF-linux-x86_64.zip)
+  * It is built on Ubuntu 20.04 and requires glibc 2.31 or newer.
+- macOS x86_64: [`FBX2glTF-macos-x86_64.zip`](https://github.com/godotengine/FBX2glTF/releases/latest/download/FBX2glTF-macos-x86_64.zip)
+  * It should work fine for macOS ARM64 too using Rosetta 2.
+- Windows x86_64: [`FBX2glTF-windows-x86_64.zip`](https://github.com/godotengine/FBX2glTF/releases/latest/download/FBX2glTF-windows-x86_64.zip)
+  * [**Requires Microsot Visual C++ Redistributable.**](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist)
 
-`FBX2glTF.exe` is for Windows. **REQUIRES MVSC redistributable on Windows** https://support.microsoft.com/en-ca/help/2977003/the-latest-supported-visual-c-downloads
+There are also artifacts of the latest commit for Linux, macOS, and Windows
+in the [GitHub Actions](https://github.com/godotengine/FBX2glTF/actions) tab.
 
-## Build Instructions
+## Build instructions
 
-Reference the Github workflow.
-
-There are artifacts in the Github Actions for Windows, MacOS and Linux.
+Reference the [GitHub workflow](https://github.com/godotengine/FBX2glTF/blob/master/.github/workflows/build.yaml).


### PR DESCRIPTION
Packaging:

- Use `FBX2glTF-<platform>-<arch>` format consistently for binaries.
- Zip binary + licenses for the GitHub Releases.
- Rename licenses to `FBX-SDK-License.{rtf,txt}` and `FBX2glTF-License.txt`.
- Include licenses together with the artifacts for each platform.
- Don't upload the licenses as a separate artifact, it gets zipped so it's not
  convenient. We still upload them as files to GH Releases though which we can
  link directly.

CI setup:

- Rename jobs for consistency.
- Bump to actions/checkout@v3 and setup-python@v4.