### PR TITLE
Fix build by locking conan version to most recent 1.x to resolve incompatibilities with conan 2.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install conan
         run: |
-          pip install --upgrade conan
+          pip install --upgrade conan==1.58
         shell: bash
 
       - name: Setup conan profile
@@ -116,7 +116,7 @@ jobs:
 
       - name: Install conan
         run: |
-          pip install --upgrade conan
+          pip install --upgrade conan==1.58
         shell: bash
 
       - name: Setup conan profile
@@ -212,7 +212,7 @@ jobs:
 
       - name: Install conan
         run: |
-          pip install --upgrade conan
+          pip install --upgrade conan==1.58
         shell: bash
 
       - name: Setup conan profile


### PR DESCRIPTION
When trying to build from example in the build.yaml I realised that the conan version was not locked during building and since 2.x has released in the meantime which changed the api this broke the GitHub actions build. Locking the version to 1.58 for now seems to repair the build. I have little to no knowledge of conan so i would know how to upgrade to 2.x.