### PR TITLE
Preserve skeletons which do not contain a mesh

### DIFF
--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -853,6 +853,18 @@ ModelData* Raw2Gltf(
       }
     }
 
+    std::vector<std::vector<uint32_t>> extraJointIndexes;
+    extraJointIndexes.resize(raw.GetExtraSkinCount());
+    for (int i = 0; i < raw.GetNodeCount(); i++) {
+      const RawNode& node = raw.GetNode(i);
+      if (node.extraSkinIx >= 0) {
+        extraJointIndexes[node.extraSkinIx].push_back(i);
+      }
+    }
+    for (int i = 0; i < extraJointIndexes.size(); i++) {
+      gltf->skins.hold(new SkinData(extraJointIndexes[i], true));
+    }
+
     //
     // cameras
     //

--- a/src/gltf/properties/SkinData.cpp
+++ b/src/gltf/properties/SkinData.cpp
@@ -18,9 +18,22 @@ SkinData::SkinData(
     : Holdable(),
       joints(joints),
       inverseBindMatrices(inverseBindMatricesAccessor.ix),
-      skeletonRootNode(skeletonRootNode.ix) {}
+      skeletonRootNode(skeletonRootNode.ix),
+      isExtraSkin(false) {}
+
+SkinData::SkinData(
+    const std::vector<uint32_t> joints,
+    bool isExtraSkin)
+    : Holdable(),
+      joints(joints),
+      inverseBindMatrices(0),
+      skeletonRootNode(0),
+      isExtraSkin(true) {}
 
 json SkinData::serialize() const {
+  if (isExtraSkin) {
+    return {{"joints", joints}};
+  }
   return {
       {"joints", joints},
       {"inverseBindMatrices", inverseBindMatrices},

--- a/src/gltf/properties/SkinData.hpp
+++ b/src/gltf/properties/SkinData.hpp
@@ -16,9 +16,14 @@ struct SkinData : Holdable {
       const AccessorData& inverseBindMatricesAccessor,
       const NodeData& skeletonRootNode);
 
+  SkinData(
+      const std::vector<uint32_t> joints,
+      bool isExtraSkin);
+
   json serialize() const override;
 
   const std::vector<uint32_t> joints;
   const uint32_t skeletonRootNode;
   const uint32_t inverseBindMatrices;
+  const bool isExtraSkin;
 };

--- a/src/raw/RawModel.cpp
+++ b/src/raw/RawModel.cpp
@@ -69,7 +69,7 @@ size_t RawVertex::Difference(const RawVertex& other) const {
   return attributes;
 }
 
-RawModel::RawModel() : vertexAttributes(0) {}
+RawModel::RawModel() : nextExtraSkinIx(0), rootNodeId(0), vertexAttributes(0), globalMaxWeights(0) {}
 
 void RawModel::AddVertexAttribute(const RawVertexAttribute attrib) {
   vertexAttributes |= attrib;
@@ -311,7 +311,7 @@ int RawModel::AddCameraOrthographic(
   return (int)cameras.size() - 1;
 }
 
-int RawModel::AddNode(const long id, const char* name, const long parentId) {
+int RawModel::AddNode(const long id, const char* name, const long parentId, const int extraSkinIx) {
   assert(name[0] != '\0');
 
   for (size_t i = 0; i < nodes.size(); i++) {
@@ -330,6 +330,7 @@ int RawModel::AddNode(const long id, const char* name, const long parentId) {
   joint.translation = Vec3f(0, 0, 0);
   joint.rotation = Quatf(0, 0, 0, 1);
   joint.scale = Vec3f(1, 1, 1);
+  joint.extraSkinIx = extraSkinIx;
 
   nodes.emplace_back(joint);
   return (int)nodes.size() - 1;

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -355,6 +355,7 @@ struct RawNode {
   long surfaceId;
   long lightIx;
   std::vector<std::string> userProperties;
+  int extraSkinIx;
 };
 
 class RawModel {
@@ -410,7 +411,7 @@ class RawModel {
       const float nearZ,
       const float farZ);
   int AddNode(const RawNode& node);
-  int AddNode(const long id, const char* name, const long parentId);
+  int AddNode(const long id, const char* name, const long parentId, const int extraSkinIx);
   void SetRootNode(const long nodeId) {
     rootNodeId = nodeId;
   }
@@ -541,9 +542,19 @@ class RawModel {
       const int keepAttribs,
       const bool forceDiscrete) const;
 
+  int CreateExtraSkinIndex() {
+    int ret = nextExtraSkinIx;
+    nextExtraSkinIx++;
+    return ret;
+  }
+  int GetExtraSkinCount() const {
+    return nextExtraSkinIx;
+  }
+
  private:
   Vec3f getFaceNormal(int verts[3]) const;
 
+  int nextExtraSkinIx;
   long rootNodeId;
   int vertexAttributes;
   int globalMaxWeights;


### PR DESCRIPTION
Generates an extra unused glTF skin for each node hierarchy with a FBXSkeleton, regardless of whether that node is connected to an existing skin.

Fixes #19

Should solve import for some Mixamo animations.
See also https://twitter.com/KenneyNL/status/1666528263890522126
