### PR TITLE
Reset to the first animation in the stack

### DIFF
--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -997,6 +997,10 @@ static void ReadAnimations(RawModel& raw, FbxScene* pScene, const GltfOptions& o
           (float)totalSizeInBytes * 1e-6f);
     }
   }
+  if (animationCount > 0) {
+    FbxAnimStack* pAnimStack = pScene->GetSrcObject<FbxAnimStack>(0);
+    pScene->SetCurrentAnimationStack(pAnimStack);
+  }
 }
 
 static std::string FindFileLoosely(
@@ -1182,6 +1186,12 @@ bool LoadFBXFile(
   }
   // this is always 0.01, but let's opt for clarity.
   scaleFactor = FbxSystemUnit::m.GetConversionFactorFrom(FbxSystemUnit::cm);
+
+  const int animationCount = pScene->GetSrcObjectCount<FbxAnimStack>();
+  if (animationCount > 0) {
+    FbxAnimStack* pAnimStack = pScene->GetSrcObject<FbxAnimStack>(0);
+    pScene->SetCurrentAnimationStack(pAnimStack);
+  }
 
   ReadNodeHierarchy(raw, pScene, pScene->GetRootNode(), 0, "", -1);
   ReadNodeAttributes(raw, pScene, pScene->GetRootNode(), textureLocations);


### PR DESCRIPTION
FBX files may contain multiple AnimationStack objects, in which the first is expected to be used as a rest pose. This is the case in kenney's assets at https://kenney.nl/assets/series:Animated%20Characters

I have verified that other FBX implementations take the ordering of AnimationStack into account and use the first item to determine the rest pose. However, the way the code here is written, it may leave it on the last animation rather than the first.