### PR TITLE
Sign and notarize macOS workflow artifact

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: "Build FBX2glTF"
 on:
   pull_request:
     branches:
-    - master
+      - master
   push:
     branches:
       - master
@@ -107,7 +107,6 @@ jobs:
           name: FBX2glTF-windows-x86_64
           path: FBX2glTF-windows-x86_64/*
 
-
   build-linux:
     runs-on: ubuntu-20.04
     steps:
@@ -198,7 +197,6 @@ jobs:
           name: FBX2glTF-linux-x86_64
           path: FBX2glTF-linux-x86_64/*
 
-
   build-macos:
     runs-on: macos-11
     steps:
@@ -208,7 +206,7 @@ jobs:
       - name: Update python
         uses: actions/setup-python@v4
         with:
-          python-version: '3'
+          python-version: "3"
 
       - name: Install conan
         run: |
@@ -272,9 +270,38 @@ jobs:
           ./build/FBX2glTF --help
         shell: bash
 
+      - name: Install the Apple certificate and provisioning profile
+        env:
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
+          P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
+        run: |
+          # create variables
+          CERTIFICATE_PATH=$RUNNER_TEMP/build_certificate.p12
+          PP_PATH=$RUNNER_TEMP/build_pp.provisionprofile
+          KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
+
+          # import certificate and provisioning profile from secrets
+          echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
+          echo -n "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o $PP_PATH
+
+          # create temporary keychain
+          security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+          security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
+
+          # import certificate to keychain
+          security import $CERTIFICATE_PATH -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k $KEYCHAIN_PATH
+          security list-keychain -d user -s $KEYCHAIN_PATH
+
+          # apply provisioning profile
+          mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
+          cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
+
       - name: Adhoc signature
         run: |
-          codesign -s - --options=runtime build/FBX2glTF
+          codesign -s build_certificate --options=runtime build/FBX2glTF
         shell: bash
 
       - name: Prepare artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -299,7 +299,7 @@ jobs:
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles
 
-      - name: Adhoc signature
+      - name: Sign binary
         run: |
           codesign -s build_certificate --options=runtime build/FBX2glTF
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -314,6 +314,28 @@ jobs:
           7z a -r $TARGET.zip $TARGET
         shell: bash
 
+      - name: Submit artifact for notarization
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          xcrun notarytool submit \
+            --apple-id $APPLE_ID \
+            --team-id $APPLE_TEAM_ID \
+            --password $APPLE_APP_SPECIFIC_PASSWORD \
+            --wait \
+            $TARGET.zip
+        shell: bash
+
+      - name: Staple distribution files
+        run: |
+          xcrun stapler staple $TARGET/FBX-SDK-License.rtf
+          xcrun stapler staple $TARGET/FBX2glTF-License.txt
+          xcrun stapler staple $TARGET/FBX2glTF-macos-x86_64
+          7z a -r $TARGET.zip $TARGET
+        shell: bash
+
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/')


### PR DESCRIPTION
This pull request aims to integrate signing and notarization into the macOS portion of the build workflow. It has been created before it is ready to be merged because this is something I can't test on my local machine and so heavy review is necessary.

The changes made require new GitHub secrets to be created. They are as follows:

- `BUILD_CERTIFICATE_BASE64`: This is the `p12` certificate file. Use the following command to convert your certificate to Base64 and copy it to your clipboard:
  ```
  base64 -i BUILD_CERTIFICATE.p12 | pbcopy
  ```
- `P12_PASSWORD`: The password for the Apple signing certificate.
- `BUILD_PROVISION_PROFILE_BASE64 `: The Apple provisioning profile. Use the following command to convert your provisioning profile to Base64 and copy it to your clipboard:
  ```
  base64 -i PROVISIONING_PROFILE.provisionprofile | pbcopy
  ```
- `KEYCHAIN_PASSWORD`: A keychain password. A new keychain will be created on the runner, so the password for the new keychain can be any new random string.
- `APPLE_ID`: The Apple ID associated with the developer account.
- `APPLE_TEAM_ID`: The Apple Developer account team ID.
- `APPLE_APP_SPECIFIC_PASSWORD`: A 2FA password for this specific app. See [Using app-specific passwords](https://support.apple.com/en-us/HT204397).

Before approving the workflow for this pull request, remember that it will certainly fail unless these GitHub secrets have been properly set.

[This GitHub Docs page](https://docs.github.com/en/actions/deployment/deploying-xcode-applications/installing-an-apple-certificate-on-macos-runners-for-xcode-development) was used for reference.