### PR TITLE
Fix installing conan in build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -212,7 +212,8 @@ jobs:
 
       - name: Install conan
         run: |
-          pip install --upgrade conan==1.58
+          echo "Cython<3" > cython_constraint.txt
+          PIP_CONSTRAINT=cython_constraint.txt pip install --upgrade conan==1.58
         shell: bash
 
       - name: Setup conan profile

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: "Build FBX2glTF"
 on:
   pull_request:
     branches:
-    - master
+      - master
   push:
     branches:
       - master
@@ -107,7 +107,6 @@ jobs:
           name: FBX2glTF-windows-x86_64
           path: FBX2glTF-windows-x86_64/*
 
-
   build-linux:
     runs-on: ubuntu-20.04
     steps:
@@ -198,7 +197,6 @@ jobs:
           name: FBX2glTF-linux-x86_64
           path: FBX2glTF-linux-x86_64/*
 
-
   build-macos:
     runs-on: macos-11
     steps:
@@ -208,12 +206,11 @@ jobs:
       - name: Update python
         uses: actions/setup-python@v4
         with:
-          python-version: '3'
+          python-version: "3.11"
 
       - name: Install conan
         run: |
-          echo "Cython<3" > cython_constraint.txt
-          PIP_CONSTRAINT=cython_constraint.txt pip install --upgrade conan==1.58
+          pip install --upgrade conan==1.58
         shell: bash
 
       - name: Setup conan profile


### PR DESCRIPTION
Attempt to fix the error about getting requirements to build wheel in the build workflow when installing conan in the macOS runner.