### PR TITLE
Assorted dependency updates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -102,7 +102,7 @@ jobs:
             FBX2glTF-windows-x86_64/FBX-SDK-License.rtf
 
       - name: FBX2glTF-windows-x86_64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FBX2glTF-windows-x86_64
           path: FBX2glTF-windows-x86_64/*
@@ -192,7 +192,7 @@ jobs:
           files: FBX2glTF-linux-x86_64.zip
 
       - name: FBX2glTF-linux-x86_64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FBX2glTF-linux-x86_64
           path: FBX2glTF-linux-x86_64/*
@@ -287,7 +287,7 @@ jobs:
           files: FBX2glTF-macos-x86_64.zip
 
       - name: FBX2glTF-macos-x86_64
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: FBX2glTF-macos-x86_64
           path: FBX2glTF-macos-x86_64/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,10 +15,10 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: windows-2022
+    runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install conan
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,14 +15,14 @@ concurrency:
 
 jobs:
   build-windows:
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - name: Checkout
         uses: actions/checkout@v3
 
       - name: Install conan
         run: |
-          pip install --upgrade conan==1.58
+          pip install --upgrade conan==1.63.0
         shell: bash
 
       - name: Setup conan profile
@@ -111,11 +111,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install conan
         run: |
-          pip install --upgrade conan==1.58
+          pip install --upgrade conan==1.63.0
         shell: bash
 
       - name: Setup conan profile
@@ -198,19 +198,14 @@ jobs:
           path: FBX2glTF-linux-x86_64/*
 
   build-macos:
-    runs-on: macos-11
+    runs-on: macos-13
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - name: Update python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
+        uses: actions/checkout@v4
 
       - name: Install conan
         run: |
-          pip install --upgrade conan==1.58
+          pip install --upgrade conan==1.63.0
         shell: bash
 
       - name: Setup conan profile

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ set(LIB_SOURCE_FILES
 )
 
 add_library(libFBX2glTF STATIC ${LIB_SOURCE_FILES})
-set_target_properties(libFBX2glTF PROPERTIES OUTPUT_NAME "FBX2glTF")
+set_target_properties(libFBX2glTF PROPERTIES OUTPUT_NAME "libFBX2glTF")
 add_executable(FBX2glTF src/FBX2glTF.cpp)
 set_target_properties(FBX2glTF PROPERTIES OUTPUT_NAME "FBX2glTF")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # DRACO
 ExternalProject_Add(Draco
   GIT_REPOSITORY https://github.com/google/draco
-  GIT_TAG 75b82f7b68c797b4e0ff5e73ca8a81e2db3db797
+  GIT_TAG 8786740086a9f4d83f44aa83badfbea4dce7a1b5
   PREFIX draco
   INSTALL_DIR
   CMAKE_ARGS

--- a/conanfile.py
+++ b/conanfile.py
@@ -9,11 +9,11 @@ from conans import ConanFile, CMake
 class FBX2glTFConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
     requires = (
-        ("boost/1.78.0"),
-        ("libiconv/1.15"),
-        ("zlib/1.2.11"),
-        ("libxml2/2.9.12"),
-        ("fmt/5.3.0"),
+        "boost/1.84.0",
+        "libiconv/1.17",
+        "zlib/1.3.1",
+        "libxml2/2.12.5",
+        "fmt/5.3.0",
     )
     generators = "cmake_find_package", "cmake_paths"
 


### PR DESCRIPTION
These updates fix building the project on my up to date Linux box due to missing cstdint headers on the older Draco versions it was pinned to, and bumps Conan 1.x to the latest semver-compatible release, which also introduces support for newer GCC compilers.

While at it, I've also bumped the GitHub Actions checkout version tag to v4, from v3, and the runner image versions. The Ubuntu runner version was purposefully not updated to avoid the risk of making binaries less portable than before due to a bump in the `glibc` version that the compiler will link to.

I've also considered updating the project to Conan 2, but that seemed a bit delicate, so I didn't want to delve into such a task just yet. Let me know if that'd be a welcome change, and if so I can see if I can spend some time figuring that out!