### PR TITLE
Fix GeometricTransform (fix #56)

### DIFF
--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -173,22 +173,6 @@ static void ReadMesh(
                              : "NO");
   }
 
-  // // The FbxNode geometric transformation describes how a FbxNodeAttribute is offset from
-  // // the FbxNode's local frame of reference. These geometric transforms are applied to the
-  // // FbxNodeAttribute after the FbxNode's local transforms are computed, and are not
-  // // inherited across the node hierarchy.
-  // // Apply the geometric transform to the mesh geometry (vertices, normal etc.) because
-  // // glTF does not have an equivalent to the geometric transform.
-  // const FbxVector4 meshTranslation = pNode->GetGeometricTranslation(FbxNode::eSourcePivot);
-  // const FbxVector4 meshRotation = pNode->GetGeometricRotation(FbxNode::eSourcePivot);
-  // const FbxVector4 meshScaling = pNode->GetGeometricScaling(FbxNode::eSourcePivot);
-  // const FbxAMatrix meshTransform(meshTranslation, meshRotation, meshScaling);
-
-  // // Remove translation & scaling from transforms that will bi applied to normals, tangents &
-  // // binormals
-  //const FbxMatrix normalTransform(FbxVector4(), meshRotation, meshScaling);
-  //const FbxMatrix inverseTransposeTransform = normalTransform.Inverse().Transpose();
-  
   // TEMP HACK
   FbxAMatrix dummyTransform;
   dummyTransform.SetIdentity();

--- a/src/fbx/Fbx2Raw.cpp
+++ b/src/fbx/Fbx2Raw.cpp
@@ -173,21 +173,27 @@ static void ReadMesh(
                              : "NO");
   }
 
-  // The FbxNode geometric transformation describes how a FbxNodeAttribute is offset from
-  // the FbxNode's local frame of reference. These geometric transforms are applied to the
-  // FbxNodeAttribute after the FbxNode's local transforms are computed, and are not
-  // inherited across the node hierarchy.
-  // Apply the geometric transform to the mesh geometry (vertices, normal etc.) because
-  // glTF does not have an equivalent to the geometric transform.
-  const FbxVector4 meshTranslation = pNode->GetGeometricTranslation(FbxNode::eSourcePivot);
-  const FbxVector4 meshRotation = pNode->GetGeometricRotation(FbxNode::eSourcePivot);
-  const FbxVector4 meshScaling = pNode->GetGeometricScaling(FbxNode::eSourcePivot);
-  const FbxAMatrix meshTransform(meshTranslation, meshRotation, meshScaling);
-  const FbxMatrix transform = meshTransform;
+  // // The FbxNode geometric transformation describes how a FbxNodeAttribute is offset from
+  // // the FbxNode's local frame of reference. These geometric transforms are applied to the
+  // // FbxNodeAttribute after the FbxNode's local transforms are computed, and are not
+  // // inherited across the node hierarchy.
+  // // Apply the geometric transform to the mesh geometry (vertices, normal etc.) because
+  // // glTF does not have an equivalent to the geometric transform.
+  // const FbxVector4 meshTranslation = pNode->GetGeometricTranslation(FbxNode::eSourcePivot);
+  // const FbxVector4 meshRotation = pNode->GetGeometricRotation(FbxNode::eSourcePivot);
+  // const FbxVector4 meshScaling = pNode->GetGeometricScaling(FbxNode::eSourcePivot);
+  // const FbxAMatrix meshTransform(meshTranslation, meshRotation, meshScaling);
 
-  // Remove translation & scaling from transforms that will bi applied to normals, tangents &
-  // binormals
-  const FbxMatrix normalTransform(FbxVector4(), meshRotation, meshScaling);
+  // // Remove translation & scaling from transforms that will bi applied to normals, tangents &
+  // // binormals
+  //const FbxMatrix normalTransform(FbxVector4(), meshRotation, meshScaling);
+  //const FbxMatrix inverseTransposeTransform = normalTransform.Inverse().Transpose();
+  
+  // TEMP HACK
+  FbxAMatrix dummyTransform;
+  dummyTransform.SetIdentity();
+  const FbxMatrix transform = dummyTransform;
+  const FbxMatrix normalTransform = dummyTransform;
   const FbxMatrix inverseTransposeTransform = normalTransform.Inverse().Transpose();
 
   raw.AddVertexAttribute(RAW_VERTEX_ATTRIBUTE_POSITION);
@@ -741,6 +747,15 @@ static void ReadNodeHierarchy(
   node.translation = toVec3f(localTranslation) * scaleFactor;
   node.rotation = toQuatf(localRotation);
   node.scale = toVec3f(localScaling);
+
+  const FbxVector4 geometricTranslation = pNode->GetGeometricTranslation(FbxNode::eSourcePivot);
+  const FbxVector4 geometricRotation = pNode->GetGeometricRotation(FbxNode::eSourcePivot);
+  const FbxVector4 geometricScaling = pNode->GetGeometricScaling(FbxNode::eSourcePivot);
+  FbxAMatrix geometricTransform(geometricTranslation, geometricRotation, geometricScaling);
+  node.hasGeometricTransform = !geometricTransform.IsIdentity();
+  node.geometricTranslation = toVec3f(geometricTransform.GetT()) * scaleFactor;
+  node.geometricRotation = toQuatf(geometricTransform.GetQ());
+  node.geometricScaling = toVec3f(geometricTransform.GetS());
 
   if (parentId) {
     RawNode& parentNode = raw.GetNode(raw.GetNodeById(parentId));

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -822,7 +822,6 @@ ModelData* Raw2Gltf(
 
     for (int i = 0; i < raw.GetNodeCount(); i++) {
       const RawNode& node = raw.GetNode(i);
-      //auto nodeData = gltf->nodes.ptrs[i];
       auto nodeData = nodesById[node.id];
 
       //

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -822,7 +822,8 @@ ModelData* Raw2Gltf(
 
     for (int i = 0; i < raw.GetNodeCount(); i++) {
       const RawNode& node = raw.GetNode(i);
-      auto nodeData = gltf->nodes.ptrs[i];
+      //auto nodeData = gltf->nodes.ptrs[i];
+      auto nodeData = nodesById[node.id];
 
       //
       // Assign mesh to node
@@ -832,7 +833,18 @@ ModelData* Raw2Gltf(
         const RawSurface& rawSurface = raw.GetSurface(surfaceIndex);
 
         MeshData& meshData = require(meshBySurfaceId, rawSurface.id);
-        nodeData->SetMesh(meshData.ix);
+
+        if (node.hasGeometricTransform) {
+          const auto meshNodeIx = gltf->nodes.ptrs.size();
+          auto meshNodeData = gltf->nodes.hold(
+            new NodeData(node.name + "-[Mesh]", node.geometricTranslation, node.geometricRotation, node.geometricScaling, false)
+          );
+          meshNodeData->SetMesh(meshData.ix);  
+          nodeData->AddChildNode(meshNodeIx);
+        } else {
+          nodeData->SetMesh(meshData.ix);
+        }
+        
 
         //
         // surface skin
@@ -937,7 +949,7 @@ ModelData* Raw2Gltf(
       }
       for (int i = 0; i < raw.GetNodeCount(); i++) {
         const RawNode& node = raw.GetNode(i);
-        const auto nodeData = gltf->nodes.ptrs[i];
+        const auto nodeData = nodesById[node.id];;
 
         if (node.lightIx >= 0) {
           // we lean on the fact that in this simple case, raw and gltf indexing are aligned

--- a/src/gltf/Raw2Gltf.cpp
+++ b/src/gltf/Raw2Gltf.cpp
@@ -836,7 +836,7 @@ ModelData* Raw2Gltf(
         if (node.hasGeometricTransform) {
           const auto meshNodeIx = gltf->nodes.ptrs.size();
           auto meshNodeData = gltf->nodes.hold(
-            new NodeData(node.name + "-[Mesh]", node.geometricTranslation, node.geometricRotation, node.geometricScaling, false)
+            new NodeData(node.name + "GeometricHelper", node.geometricTranslation, node.geometricRotation, node.geometricScaling, false)
           );
           meshNodeData->SetMesh(meshData.ix);  
           nodeData->AddChildNode(meshNodeIx);

--- a/src/raw/RawModel.hpp
+++ b/src/raw/RawModel.hpp
@@ -349,9 +349,16 @@ struct RawNode {
   std::string name;
   long parentId;
   std::vector<long> childIds;
+
   Vec3f translation;
   Quatf rotation;
   Vec3f scale;
+
+  bool hasGeometricTransform;
+  Vec3f geometricTranslation;
+  Quatf geometricRotation;
+  Vec3f geometricScaling;
+
   long surfaceId;
   long lightIx;
   std::vector<std::string> userProperties;


### PR DESCRIPTION
when Fbx node has GeometricTransform, use an additional Gltf node to hold the mesh and the transform. fix #56 