### PR TITLE
Don't write buffers section if buffer is empty

### DIFF
--- a/src/gltf/GltfModel.hpp
+++ b/src/gltf/GltfModel.hpp
@@ -191,9 +191,14 @@ class GltfModel {
     if (!holder.ptrs.empty()) {
       std::vector<json> bits;
       for (const auto& ptr : holder.ptrs) {
-        bits.push_back(ptr->serialize());
+        json bit = ptr->serialize();
+        if (!bit.empty()) {
+          bits.push_back(ptr->serialize());
+        }
       }
-      glTFJson[key] = bits;
+      if (!bits.empty()) {
+        glTFJson[key] = bits;
+      }
     }
   }
 

--- a/src/gltf/properties/BufferData.cpp
+++ b/src/gltf/properties/BufferData.cpp
@@ -20,7 +20,7 @@ BufferData::BufferData(
     : Holdable(), isGlb(false), uri(isEmbedded ? "" : std::move(uri)), binData(binData) {}
 
 json BufferData::serialize() const {
-  if (binData->size() == 0) {
+  if (binData->empty()) {
     return json{};
   }
     

--- a/src/gltf/properties/BufferData.cpp
+++ b/src/gltf/properties/BufferData.cpp
@@ -20,6 +20,10 @@ BufferData::BufferData(
     : Holdable(), isGlb(false), uri(isEmbedded ? "" : std::move(uri)), binData(binData) {}
 
 json BufferData::serialize() const {
+  if (binData->size() == 0) {
+    return json{};
+  }
+    
   json result{{"byteLength", binData->size()}};
   if (!isGlb) {
     if (!uri.empty()) {


### PR DESCRIPTION
I have an fbx file that when procced through FBX2gLTF produced the buffers json segment as:

```
"buffers": [
{
"byteLength": 0
}
],
```

Which is not valid in gltf. Instead, omit this from being written to the file by only writing non-empty json.